### PR TITLE
Use wviminfo! to update history

### DIFF
--- a/denops/@ddu-sources/command_history.ts
+++ b/denops/@ddu-sources/command_history.ts
@@ -72,6 +72,14 @@ export class Source extends BaseSource<Params> {
           const action = item?.action as ActionData;
           if (item.action) {
             await fn.histdel(denops, "cmd", action.index);
+
+            // Note: rviminfo! is broken in Vim8 before 8.2.2494
+            if (
+              await fn.has(denops, "nvim") ||
+              await fn.has(denops, "patch-8.2.2494")
+            ) {
+              await denops.cmd("wviminfo! | rviminfo!");
+            }
           }
         }
       });


### PR DESCRIPTION
`wviminfo!` is needed.  Because `histdel()` only changes current state.
If you restart Vim, the deletion is canceled.